### PR TITLE
Use mtime instead of ctime (fixes #1)

### DIFF
--- a/init.R
+++ b/init.R
@@ -52,9 +52,9 @@ get_new_tweets <- function(max_id) {
 
 needs_pulled <- FALSE
 if (file.exists(cacheFile)) {
-  cacheTime = file.info(cacheFile)$ctime
+  cacheTime = file.info(cacheFile)$mtime
   cacheAge = difftime(Sys.time(), cacheTime, units="min")
-  initRAge = difftime(Sys.time(), file.info('init.R')$ctime, units = 'min')
+  initRAge = difftime(Sys.time(), file.info('init.R')$mtime, units = 'min')
   needs_pulled <- as.numeric(cacheAge) > 15 | as.numeric(initRAge) < as.numeric(cacheAge)
   rsconf_tweets <- readRDS(cacheFile)
 } else {


### PR DESCRIPTION
See #1 

I may be wrong (haven't investigated in much detail), but I think `mtime` should be relatively platform agnostic and more suitable for this particular use case.

e.g. see https://www.unixtutorial.org/2008/04/atime-ctime-mtime-in-unix-filesystems/
> mtime – File Modify Time
Last modification time shows time of the  last change to file's contents. It does not change with owner or permission changes, and is therefore used for tracking the actual changes to data of the file itself.